### PR TITLE
Bug fixes: Exposing Image List and Container Remove by client.

### DIFF
--- a/cmd/container_remove.go
+++ b/cmd/container_remove.go
@@ -22,7 +22,7 @@ import (
 
 var cntRemoveCmd = &cobra.Command{
 	Use:   "remove",
-	Short: "remove a container by intance name",
+	Short: "remove a container by instance name",
 	RunE: func(command *cobra.Command, args []string) error {
 		if instance == "" {
 			fmt.Println("--instance must be provided")
@@ -38,7 +38,7 @@ var cntRemoveCmd = &cobra.Command{
 }
 
 func init() {
-	containerCmd.AddCommand(cntStopCmd)
+	containerCmd.AddCommand(cntRemoveCmd)
 
 	cntRemoveCmd.PersistentFlags().StringVar(&instance, "instance", "", "Container instance to remove.")
 	cntRemoveCmd.PersistentFlags().BoolVar(&force, "force", false, "Forcefully remove the container.")

--- a/cmd/container_stop.go
+++ b/cmd/container_stop.go
@@ -26,7 +26,7 @@ var (
 
 var cntStopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "stop a container by intance name",
+	Short: "stop a container by instance name",
 	RunE: func(command *cobra.Command, args []string) error {
 		if instance == "" {
 			fmt.Println("--instance must be provided")

--- a/cmd/image_list.go
+++ b/cmd/image_list.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var imageListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List images",
+	RunE: func(command *cobra.Command, args []string) error {
+		ch, err := containerzClient.ListImage(command.Context(), limit, nil)
+		if err != nil {
+			return err
+		}
+
+		writer := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)
+		fmt.Fprint(writer, "ID\tName\tTag\n")
+		defer writer.Flush()
+		for info := range ch {
+			if info.Error != nil {
+				return info.Error
+			}
+			fmt.Fprintf(writer, "%s\t%s\t%s\n", info.ID, info.ImageName, info.ImageTag)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	imageCmd.AddCommand(imageListCmd)
+	imageListCmd.PersistentFlags().BoolVar(&all, "all", false, "Return all images.")
+	imageListCmd.PersistentFlags().Int32Var(&limit, "limit", -1, "Number of images to return")
+}

--- a/containers/docker/container_start_test.go
+++ b/containers/docker/container_start_test.go
@@ -95,7 +95,7 @@ func TestContainerStart(t *testing.T) {
 			wantErr: status.Error(codes.NotFound, "image no-such-image:no-such-tag not found"),
 		},
 		{
-			name:    "container-with-intance-name-exists",
+			name:    "container-with-instance-name-exists",
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   "my-cmd",


### PR DESCRIPTION
### Solving the open issues: https://github.com/openconfig/containerz/issues/9, https://github.com/openconfig/containerz/issues/15

### List Image is not exposed - https://github.com/openconfig/containerz/issues/9
Operation **list image** was already implemented under **client/list_image.go**, but there is no cobra command connecting it to Image operation in the cli.
I added a new cobra command under **Image** command, to expose it to the client.
I also print the RPC response in a table of the desired format, containing the image ID, name and tag.

### Remove Container is not exposed - https://github.com/openconfig/containerz/issues/15
Operation is not exposed to client.
Instead, container stop is accidentally shown twice.
I fixed the bug + some typos.