### PR TITLE
server: add WithGrpcServer

### DIFF
--- a/server/options_test.go
+++ b/server/options_test.go
@@ -16,6 +16,8 @@ package server
 
 import (
 	"testing"
+
+	"google.golang.org/grpc"
 )
 
 func TestWithAddr(t *testing.T) {
@@ -45,5 +47,22 @@ func TestWithChunkSize(t *testing.T) {
 
 	if s.chunkSize != 10 {
 		t.Errorf("WithChunkSize(10) returned %d", s.chunkSize)
+	}
+}
+
+func TestWithGrpcServer(t *testing.T) {
+	s := &Server{}
+
+	srv := grpc.NewServer()
+	WithGrpcServer(srv)(s)
+
+	if s.grpcServer != srv {
+		t.Fatal("WithGrpcServer did not set first server")
+	}
+
+	srv2 := grpc.NewServer()
+	WithGrpcServer(srv2)(s)
+	if s.grpcServer != srv2 {
+		t.Fatal("WithGrpcServer did not set second server")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -17,12 +17,15 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 
-	"google.golang.org/grpc"
-	"k8s.io/klog/v2"
 	"github.com/openconfig/containerz/containers"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 
 	cpb "github.com/openconfig/gnoi/containerz"
 )
@@ -206,29 +209,44 @@ type Server struct {
 
 // New constructs a new containerz server
 func New(mgr containerManager, opts ...Option) *Server {
+
 	s := &Server{
-		grpcServer:  grpc.NewServer(),
-		tmpLocation: "/tmp",
-		chunkSize:   5e6, // 5mb chunks
-		mgr:         mgr,
-		addr:        ":9999",
+		mgr: mgr,
+	}
+	defaultOptions := []Option{
+		WithGrpcServer(grpc.NewServer()),
+		WithTempLocation("/tmp"),
+		WithChunkSize(5e6), // 5mb chunks,
+		WithAddr(":9999"),
 	}
 
-	for _, opt := range opts {
+	for _, opt := range append(defaultOptions, opts...) {
 		opt(s)
 	}
 
-	var err error
-	s.lis, err = net.Listen("tcp", s.addr)
-	if err != nil {
-		klog.Fatalf("server start: %e", err)
+	// only start the listener if the Server has been set up with an address
+	if s.addr != "" {
+		var err error
+		s.lis, err = net.Listen("tcp", s.addr)
+		if err != nil {
+			klog.Fatalf("server start: %e", err)
+		}
 	}
 
 	return s
 }
 
 // Serve starts this instance of the containerz server.
-func (s *Server) Serve(ctx context.Context) error {
+func (s *Server) Serve(_ context.Context) error {
+	if s.grpcServer == nil || s.addr == "" || s.lis == nil {
+		msg := fmt.Sprintf(
+			"cannot serve Containerz service without grpc server, listener, and address."+
+				" grpc server=%p, listener=%p, address=%q",
+			s.grpcServer, s.lis, s.addr)
+		klog.Info(msg)
+		return status.Error(codes.FailedPrecondition, msg)
+	}
+
 	klog.Info("server-start")
 	cpb.RegisterContainerzServer(s.grpcServer, s)
 
@@ -238,7 +256,11 @@ func (s *Server) Serve(ctx context.Context) error {
 }
 
 // Halt stops the containerz server gracefully.
-func (s *Server) Halt(ctx context.Context) {
+func (s *Server) Halt(_ context.Context) {
+	if s.grpcServer == nil {
+		klog.Info("halted a server which was not running (this was a no-op)")
+		return
+	}
 	klog.Info("server-stopping")
 	if s.grpcServer != nil {
 		s.grpcServer.GracefulStop()

--- a/server/server.go
+++ b/server/server.go
@@ -22,12 +22,12 @@ import (
 	"os"
 
 	"github.com/openconfig/containerz/containers"
+	cpb "github.com/openconfig/gnoi/containerz"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
-
-	cpb "github.com/openconfig/gnoi/containerz"
 )
 
 type containerManager interface {


### PR DESCRIPTION
Add WithGrpcServer option for the New function.

WithGrpcServer sets the gRPC server that the Server will be started on. It also calls Stop for the previously-configured grpcServer, which ensures that channelz entries are cleaned up (channelz entries are created at the point of calling grpc.NewServer).

This change also adds checks at (*Server).Serve and (*Server).Halt to ensure that they are only called for properly instantiated *Server structs.