### PR TITLE
container/docker: start containers without AutoRemove

### DIFF
--- a/containers/docker/container_start.go
+++ b/containers/docker/container_start.go
@@ -64,7 +64,6 @@ func (m *Manager) ContainerStart(ctx context.Context, image, tag, cmd string, op
 	hostConfig := &container.HostConfig{
 		Mounts:      mounts,
 		NetworkMode: "host",
-		AutoRemove:  true,
 
 		Resources: container.Resources{
 			NanoCPUs:          cpu,


### PR DESCRIPTION
If the AutoRemove field is set to true, then:
1. StopContainer RPC calls (including the call to StopContainer made as part of the UpdateContainer
RPC) will fail as the line
https://github.com/openconfig/containerz/blob/012a091c1a8a3d29259bc62674856be1b1dac486/containers/docker/container_stop.go#L51 will send a stop signal, as well as triggering
the container to be removed automatically.
This will cause the subsequent
m.client.ContainerRemove call to fail with an error as the container removal is already in process.

2. Containers cannot be started with a restart policy (docker will fail to start the container if it has a non-nil restart policy while AutoRemove is true.

So this field can be left as false, and the removal is ensured by the StopContainer RPC call anyway.