### PR TITLE
containers/docker: allow starting containers with more complex commands

### DIFF
--- a/containers/docker/container_start.go
+++ b/containers/docker/container_start.go
@@ -77,6 +77,10 @@ func (m *Manager) ContainerStart(ctx context.Context, image, tag, cmd string, op
 		return "", status.Errorf(codes.InvalidArgument,
 			"failed to split command %q, got error %s", cmd, err)
 	}
+	if len(splitCmd) == 0 {
+		// shlex.Split on an empty string produces a length 0 (but non-nil) slice
+		splitCmd = nil
+	}
 
 	config := &container.Config{
 		Cmd:          splitCmd,

--- a/containers/docker/container_start.go
+++ b/containers/docker/container_start.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/docker/go-connections/nat"
@@ -17,6 +19,20 @@ import (
 
 	cpb "github.com/openconfig/gnoi/containerz"
 )
+
+// knownShells is a slice of shells which can be used in commands that containers
+// can be started with. All of these shells can run commands using the -c flag, like:
+// <shell> -c "<command>"
+var knownShells = []string{
+	"sh",
+	"bash",
+	"zsh",
+	"ksh",
+	"fish",
+	"tcsh",
+}
+
+const commandFlag = "-c"
 
 // ContainerStart starts a container provided the image exists and that the ports requested are not
 // currently in use.
@@ -71,9 +87,24 @@ func (m *Manager) ContainerStart(ctx context.Context, image, tag, cmd string, op
 			MemoryReservation: optionz.SoftMemory, // soft
 		},
 	}
+	splitCmd := strings.Split(cmd, " ")
+	if len(splitCmd) > 2 &&
+		splitCmd[1] == commandFlag &&
+		slices.Contains(knownShells, splitCmd[0]) {
+		// command is of the form <shell> -c "<command>"
+		quoted := strings.TrimPrefix(cmd, splitCmd[0]+" "+commandFlag+" ")
+		unquoted, err := strconv.Unquote(quoted)
+		if err != nil {
+			return "", status.Errorf(codes.InvalidArgument,
+				"expected shell command: %s to be of the form: %s -c \"<command>\"."+
+					" Failed to unquote command with error %s",
+				cmd, splitCmd[0], err)
+		}
+		splitCmd = append(splitCmd[:2], unquoted)
+	}
 
 	config := &container.Config{
-		Cmd:          strings.Split(cmd, " "),
+		Cmd:          splitCmd,
 		Labels:       optionz.Labels,
 		Image:        ref,
 		AttachStdin:  false,

--- a/containers/docker/container_start_test.go
+++ b/containers/docker/container_start_test.go
@@ -404,15 +404,15 @@ func TestContainerStart(t *testing.T) {
 				HardMemory:  2000,
 				SoftMemory:  1000,
 			},
-		}, {
+		},
+		{
 			name:    "container-with-cmd",
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `sleep 1000`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantState: &fakeStartingDocker{
 				Cmd: []string{"sleep", "1000"},
 			},
@@ -423,9 +423,8 @@ func TestContainerStart(t *testing.T) {
 			inTag:   "my-tag",
 			inCmd:   `sh -c "echo 2"`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantState: &fakeStartingDocker{
 				Cmd: []string{"sh", "-c", "echo 2"},
 			},
@@ -436,9 +435,8 @@ func TestContainerStart(t *testing.T) {
 			inTag:   "my-tag",
 			inCmd:   `bash -c "echo 2"`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantState: &fakeStartingDocker{
 				Cmd: []string{"bash", "-c", "echo 2"},
 			},
@@ -449,9 +447,8 @@ func TestContainerStart(t *testing.T) {
 			inTag:   "my-tag",
 			inCmd:   `zsh -c "echo 2"`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantState: &fakeStartingDocker{
 				Cmd: []string{"zsh", "-c", "echo 2"},
 			},
@@ -462,9 +459,8 @@ func TestContainerStart(t *testing.T) {
 			inTag:   "my-tag",
 			inCmd:   `ksh -c "echo 2"`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantState: &fakeStartingDocker{
 				Cmd: []string{"ksh", "-c", "echo 2"},
 			},
@@ -475,9 +471,8 @@ func TestContainerStart(t *testing.T) {
 			inTag:   "my-tag",
 			inCmd:   `fish -c "echo 2"`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantState: &fakeStartingDocker{
 				Cmd: []string{"fish", "-c", "echo 2"},
 			},
@@ -488,9 +483,8 @@ func TestContainerStart(t *testing.T) {
 			inTag:   "my-tag",
 			inCmd:   `tcsh -c "echo 2"`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantState: &fakeStartingDocker{
 				Cmd: []string{"tcsh", "-c", "echo 2"},
 			},
@@ -501,9 +495,8 @@ func TestContainerStart(t *testing.T) {
 			inTag:   "my-tag",
 			inCmd:   `tcsh -c 'echo 2'`,
 			inSummaries: []imagetypes.Summary{{
-					RepoTags: []string{"my-image:my-tag"},
-				},
-			},
+				RepoTags: []string{"my-image:my-tag"},
+			}},
 			wantErr: status.Errorf(codes.InvalidArgument,
 				"expected shell command: tcsh -c 'echo 2' to be of the form:"+
 					` tcsh -c "<command>". Failed to unquote command with error invalid syntax`),

--- a/containers/docker/container_start_test.go
+++ b/containers/docker/container_start_test.go
@@ -409,8 +409,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `sleep 1000`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},
@@ -423,8 +422,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `sh -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},
@@ -437,8 +435,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `bash -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},
@@ -451,8 +448,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `zsh -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},
@@ -465,8 +461,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `ksh -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},
@@ -479,8 +474,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `fish -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},
@@ -493,8 +487,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `tcsh -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},
@@ -507,8 +500,7 @@ func TestContainerStart(t *testing.T) {
 			inImage: "my-image",
 			inTag:   "my-tag",
 			inCmd:   `tcsh -c 'echo 2'`,
-			inSummaries: []imagetypes.Summary{
-				imagetypes.Summary{
+			inSummaries: []imagetypes.Summary{{
 					RepoTags: []string{"my-image:my-tag"},
 				},
 			},

--- a/containers/docker/container_start_test.go
+++ b/containers/docker/container_start_test.go
@@ -430,76 +430,16 @@ func TestContainerStart(t *testing.T) {
 			},
 		},
 		{
-			name:    "container-with-bash-cmd",
+			name:    "container-with-quoted-cmd",
 			inImage: "my-image",
 			inTag:   "my-tag",
-			inCmd:   `bash -c "echo 2"`,
+			inCmd:   `echo 'echo "quoted"'`,
 			inSummaries: []imagetypes.Summary{{
 				RepoTags: []string{"my-image:my-tag"},
 			}},
 			wantState: &fakeStartingDocker{
-				Cmd: []string{"bash", "-c", "echo 2"},
+				Cmd: []string{"echo", `echo "quoted"`},
 			},
-		},
-		{
-			name:    "container-with-zsh-cmd",
-			inImage: "my-image",
-			inTag:   "my-tag",
-			inCmd:   `zsh -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{{
-				RepoTags: []string{"my-image:my-tag"},
-			}},
-			wantState: &fakeStartingDocker{
-				Cmd: []string{"zsh", "-c", "echo 2"},
-			},
-		},
-		{
-			name:    "container-with-ksh-cmd",
-			inImage: "my-image",
-			inTag:   "my-tag",
-			inCmd:   `ksh -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{{
-				RepoTags: []string{"my-image:my-tag"},
-			}},
-			wantState: &fakeStartingDocker{
-				Cmd: []string{"ksh", "-c", "echo 2"},
-			},
-		},
-		{
-			name:    "container-with-fish-cmd",
-			inImage: "my-image",
-			inTag:   "my-tag",
-			inCmd:   `fish -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{{
-				RepoTags: []string{"my-image:my-tag"},
-			}},
-			wantState: &fakeStartingDocker{
-				Cmd: []string{"fish", "-c", "echo 2"},
-			},
-		},
-		{
-			name:    "container-with-tcsh-cmd",
-			inImage: "my-image",
-			inTag:   "my-tag",
-			inCmd:   `tcsh -c "echo 2"`,
-			inSummaries: []imagetypes.Summary{{
-				RepoTags: []string{"my-image:my-tag"},
-			}},
-			wantState: &fakeStartingDocker{
-				Cmd: []string{"tcsh", "-c", "echo 2"},
-			},
-		},
-		{
-			name:    "container-with-tcsh-cmd-fail",
-			inImage: "my-image",
-			inTag:   "my-tag",
-			inCmd:   `tcsh -c 'echo 2'`,
-			inSummaries: []imagetypes.Summary{{
-				RepoTags: []string{"my-image:my-tag"},
-			}},
-			wantErr: status.Errorf(codes.InvalidArgument,
-				"expected shell command: tcsh -c 'echo 2' to be of the form:"+
-					` tcsh -c "<command>". Failed to unquote command with error invalid syntax`),
 		},
 	}
 

--- a/containers/docker/container_start_test.go
+++ b/containers/docker/container_start_test.go
@@ -441,6 +441,15 @@ func TestContainerStart(t *testing.T) {
 				Cmd: []string{"echo", `echo "quoted"`},
 			},
 		},
+		{
+			name:    "container-with-no-cmd",
+			inImage: "my-image",
+			inTag:   "my-tag",
+			inSummaries: []imagetypes.Summary{{
+				RepoTags: []string{"my-image:my-tag"},
+			}},
+			wantState: &fakeStartingDocker{},
+		},
 	}
 
 	for _, tc := range tests {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/docker v27.5.0+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/google/go-cmp v0.6.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/moby/moby v27.5.0+incompatible
 	github.com/openconfig/gnoi v0.6.1-0.20250206212518-26d177339690
 	github.com/opencontainers/image-spec v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 h1:VNqngBF40hVlDloBruUehVYC3ArSgIyScOAyMRqBxRg=


### PR DESCRIPTION
naively splitting the command by whitespace prevents containers from being started with shell commands.
This change adds support for starting containers with more complex commands (e.g. `sh -c "command"`) or commands with quoted whitespace.
This change also adds test cases for the parsing being added