### PR TITLE
containers/docker: set valid maximum timeout for force-stopping container

### DIFF
--- a/containers/docker/container_stop.go
+++ b/containers/docker/container_stop.go
@@ -46,7 +46,7 @@ func (m *Manager) ContainerStop(ctx context.Context, instance string, opts ...op
 		if ok {
 			// set the duration to half of the timeout, to ensure that after
 			// ContainerStop runs, the RPC context won't have expired
-			duration = int(timeoutTime.Sub(time.Now()).Seconds()) / 2
+			duration = int(time.Until(timeoutTime)) / 2
 			// cap duration at based on max timeout
 			duration = min(duration, maximumStopTimeout)
 		}

--- a/containers/docker/container_stop_test.go
+++ b/containers/docker/container_stop_test.go
@@ -87,7 +87,7 @@ func TestContainerStop(t *testing.T) {
 		{
 			name:       "stop-with-force-and-duration",
 			inInstance: "stop-with-force-and-duration",
-			inTimeout:  1500 * time.Millisecond,
+			inTimeout:  1 * time.Minute,
 			inOpts:     []options.Option{options.Force()},
 			inCnts: []types.Container{
 				types.Container{
@@ -96,7 +96,7 @@ func TestContainerStop(t *testing.T) {
 			},
 			wantState: &fakeStoppingDocker{
 				Instance:       "stop-with-force-and-duration",
-				Duration:       1,
+				Duration:       maximumStopTimeout,
 				RemoveInstance: "stop-with-force-and-duration",
 			},
 		},


### PR DESCRIPTION
If the ctx deadline is used as a timeout but the container does not handle SIGTERM, then by the time SIGKILL is sent, the ctx will have expired.
To fix this, spend at most half of the ctx deadline waiting before issuing the SIGKILL.

To ensure that this does not take too long (as the Force fields intention is to forcibly kill the container), the timeout is capped at a maximum of 10 seconds (which is the default timeout used by docker).

Also update the test to make it deterministic.
Previously the test could fail if the time.Now() in ContainerStop called too late.