### PR TITLE
Error return code

### DIFF
--- a/cmd/image_remove.go
+++ b/cmd/image_remove.go
@@ -33,9 +33,9 @@ var removeCmd = &cobra.Command{
 		case nil:
 			fmt.Printf("Image %s:%s has been removed.\n", image, tag)
 		case client.ErrNotFound:
-			fmt.Printf("Image %s:%s does not exist in containerz.\n", image, tag)
+			return fmt.Errorf("Image %s:%s does not exist in containerz.\n", image, tag)
 		case client.ErrRunning:
-			fmt.Printf("Image %s:%s has a container running; use force option or stop the container.\n", image, tag)
+			return fmt.Errorf("Image %s:%s has a container running; use force option or stop the container.\n", image, tag)
 		default:
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -27,8 +29,11 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   "containerz",
 	Short: "Containerz suite of CLI tools",
-	Run: func(command *cobra.Command, args []string) {
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	},
+	RunE: func(command *cobra.Command, args []string) error {
 		command.HelpFunc()(command, args)
+		return fmt.Errorf("no command specified")
 	},
 }
 


### PR DESCRIPTION
Here are two new changes:

- return code 0 if the operation was successful, otherwise return code is 1. (Linux standard)
- For errors in "image remove" - return an error rather than only print it.
 e.g. If the given image does not exist, return an error (return code 1), not only print it.