### PR TITLE
containers/docker: list all images

### DIFF
--- a/containers/docker/container_logs.go
+++ b/containers/docker/container_logs.go
@@ -18,6 +18,8 @@ func (m *Manager) ContainerLogs(ctx context.Context, instance string, srv option
 	optionz := options.ApplyOptions(opts...)
 
 	cnts, err := m.client.ContainerList(ctx, container.ListOptions{
+		// list all the containers - even ones which have exited.
+		All: true,
 		// TODO(alshabib): consider filtering for the image we care about
 	})
 	if err != nil {


### PR DESCRIPTION
If the system had no running images, then the
ContainerList call would return an empty slice,
and the RPC would exit with an error.

This change fixes the ContainerList call so that it
returns a list of all containers on the system,
including stopped ones.