### PR TITLE
containers/docker: filter plugins by name

### DIFF
--- a/containers/docker/plugin_list.go
+++ b/containers/docker/plugin_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/api/types/filters"
 
@@ -13,18 +14,21 @@ import (
 // PluginList lists all plugins on a target. If instance is not empty, it will return a plugin
 // named `instance` if it exists.
 func (m *Manager) PluginList(ctx context.Context, instance string) (*cpb.ListPluginsResponse, error) {
-	var args filters.Args
-	if instance != "" {
-		args = filters.NewArgs(filters.KeyValuePair{Key: "name", Value: instance})
-	}
-
-	resp, err := m.client.PluginList(ctx, args)
+	resp, err := m.client.PluginList(ctx, filters.Args{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list plugins: %w", err)
 	}
 
 	res := &cpb.ListPluginsResponse{}
 	for _, plugin := range resp {
+		if instance != "" {
+			// plugin.Name will have format <name>:<tag>.
+			// instance_name (from StartPluginRequest) does not have a tag,
+			// so cut off only the name here.
+			if pluginName, _, _ := strings.Cut(plugin.Name, ":"); pluginName != instance {
+				continue
+			}
+		}
 		conf, err := json.MarshalIndent(plugin.Config, "", "  ")
 		if err != nil {
 			return nil, fmt.Errorf("unable to marshal plugin config: %v", err)

--- a/containers/docker/plugin_list_test.go
+++ b/containers/docker/plugin_list_test.go
@@ -51,17 +51,7 @@ type fakePluginListingDocker struct {
 }
 
 func (f *fakePluginListingDocker) PluginList(ctx context.Context, args filters.Args) (types.PluginsListResponse, error) {
-	values := args.Get("name")
-	if len(values) == 0 {
-		return f.plugins, nil
-	}
-
-	for _, plugin := range f.plugins {
-		if plugin.Name == values[0] {
-			return []*types.Plugin{plugin}, nil
-		}
-	}
-	return nil, nil
+	return f.plugins, nil
 }
 
 func TestPluginList(t *testing.T) {


### PR DESCRIPTION
Previously attempting to run the ListPlugins RPC with an instance name
would cause the RPC to fail with error:
StatusCode=Unknown
Message="failed to list plugins: Error response from daemon: invalid filter 'name'"

This error is returned from the daemon too:
$ docker plugin list -f name=xyz
Error response from daemon: invalid filter 'name'

and supported filters are only for enabled or capability, see:
 https://docs.docker.com/reference/cli/docker/plugin/ls/#filter

This commit builds the logic for filtering into the server itself