### PR TITLE
containers/docker: make StopContainer RPC not remove containers.

### DIFF
--- a/containers/docker/container_stop.go
+++ b/containers/docker/container_stop.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/openconfig/containerz/containers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
+	"github.com/openconfig/containerz/containers"
 )
 
 // maximumStopTimeout sets a cap on how long the docker can wait before
@@ -58,7 +58,9 @@ func (m *Manager) ContainerStop(ctx context.Context, instance string, opts ...op
 	}
 
 	if err := m.client.ContainerStop(ctx, instance, container.StopOptions{Timeout: pDuration}); err != nil {
-		klog.Warningf("container %s was not running", instance)
+		klog.Warningf("container %s failed to stop", instance)
+		return status.Errorf(codes.Unknown, "failed to stop container %s with error %s",
+			instance, err)
 	}
 
 	return nil

--- a/containers/docker/container_stop.go
+++ b/containers/docker/container_stop.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/openconfig/containerz/containers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
-	"github.com/openconfig/containerz/containers"
 )
 
 // maximumStopTimeout sets a cap on how long the docker can wait before
@@ -59,12 +59,6 @@ func (m *Manager) ContainerStop(ctx context.Context, instance string, opts ...op
 
 	if err := m.client.ContainerStop(ctx, instance, container.StopOptions{Timeout: pDuration}); err != nil {
 		klog.Warningf("container %s was not running", instance)
-	}
-
-	if err := m.client.ContainerRemove(ctx, instance, container.RemoveOptions{
-		Force: optionz.Force,
-	}); err != nil {
-		return err
 	}
 
 	return nil

--- a/containers/docker/container_stop_test.go
+++ b/containers/docker/container_stop_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/openconfig/containerz/containers"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"github.com/openconfig/containerz/containers"
 )
 
 type fakeStoppingDocker struct {

--- a/containers/docker/container_stop_test.go
+++ b/containers/docker/container_stop_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types"
+	"github.com/openconfig/containerz/containers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"github.com/openconfig/containerz/containers"
 )
 
 type fakeStoppingDocker struct {
@@ -65,9 +65,8 @@ func TestContainerStop(t *testing.T) {
 				},
 			},
 			wantState: &fakeStoppingDocker{
-				Instance:       "stop-no-force",
-				Duration:       -1,
-				RemoveInstance: "stop-no-force",
+				Instance: "stop-no-force",
+				Duration: -1,
 			},
 		},
 		{
@@ -80,8 +79,7 @@ func TestContainerStop(t *testing.T) {
 				},
 			},
 			wantState: &fakeStoppingDocker{
-				Instance:       "stop-with-force-no-duration",
-				RemoveInstance: "stop-with-force-no-duration",
+				Instance: "stop-with-force-no-duration",
 			},
 		},
 		{
@@ -95,9 +93,8 @@ func TestContainerStop(t *testing.T) {
 				},
 			},
 			wantState: &fakeStoppingDocker{
-				Instance:       "stop-with-force-and-duration",
-				Duration:       maximumStopTimeout,
-				RemoveInstance: "stop-with-force-and-duration",
+				Instance: "stop-with-force-and-duration",
+				Duration: maximumStopTimeout,
 			},
 		},
 	}

--- a/containers/docker/container_update.go
+++ b/containers/docker/container_update.go
@@ -61,6 +61,10 @@ func (m *Manager) performContainerUpdate(ctx context.Context, instance, image, t
 		// If the container stop fails, there shouldn't be any changes to restore.
 		return "", status.Errorf(codes.Internal, "failed update of instance %s due to: %v", instance, err)
 	}
+	// ContainerStop will stop the container - we want to additionally remove this instance here.
+	if err := m.client.ContainerRemove(ctx, instance, container.RemoveOptions{}); err != nil {
+		return "", status.Errorf(codes.Internal, "failed update of instance %s due to: %v", instance, err)
+	}
 
 	// Attempting to create & start a container with the new config.
 	opts = append(opts, options.WithInstanceName(instance))


### PR DESCRIPTION
StopContainer should only stop containers.
RemoveContainer should be used to remove containers if necessary.