### PR TITLE
Prioritize sending messages in nonBlockingChannelSend

### DIFF
--- a/client/push.go
+++ b/client/push.go
@@ -171,7 +171,7 @@ type transferTypes interface {
 		*cpb.DeployResponse_ImageTransferSuccess
 }
 
-func recvMsgOrSendError[T transferTypes](ctx context.Context, ch chan *Progress, dCli cpb.Containerz_DeployClient) T {
+func recvMsgOrSendError[T transferTypes](ctx context.Context, ch chan<- *Progress, dCli cpb.Containerz_DeployClient) T {
 	msg, err := dCli.Recv()
 	if err != nil {
 		nonBlockingChannelSend(ctx, ch, &Progress{

--- a/client/types.go
+++ b/client/types.go
@@ -177,7 +177,14 @@ func WithHardLimit(mem int64) StartOption {
 
 // nonBlockingChannelSend attempts to send a message in a non blocking manner. If the context is
 // cancelled it simply returns with an indication that the context was cancelled
-func nonBlockingChannelSend[T nonBlockTypes](ctx context.Context, ch chan T, data T) bool {
+func nonBlockingChannelSend[T nonBlockTypes](ctx context.Context, ch chan<- T, data T) bool {
+	// Prioritize sending the data over checking the context.
+	select {
+	case ch <- data:
+		return false
+	default:
+	}
+	
 	select {
 	case <-ctx.Done():
 		return true

--- a/client/types_test.go
+++ b/client/types_test.go
@@ -42,6 +42,13 @@ func TestNonBlockingSend(t *testing.T) {
 			data:   &Progress{},
 			want:   true,
 		},
+		{
+			name:   "cancelled-with-ch-cap",
+			ch:     make(chan *Progress, 10),
+			cancel: true,
+			data:   &Progress{},
+			want:   false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Prioritize sending messages to the channel when both the channel and ctx.Done() are ready in `nonBLockingChannelSend`. This ensures error messages aren't discarded, which could happen if the context was cancelled (e.g., in ListContainer).

