### PR TITLE
Allow setting grpc metadata in requests and override the function to create a new containerz client

### DIFF
--- a/cmd/container.go
+++ b/cmd/container.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"github.com/openconfig/containerz/client"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/metadata"
 )
@@ -29,7 +28,7 @@ var containerCmd = &cobra.Command{
 			cmd.SetContext(ctx)
 		}
 		var err error
-		containerzClient, err = client.NewClient(cmd.Context(), addr)
+		containerzClient, err = NewClient(cmd.Context(), addr)
 		return err
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -17,12 +17,17 @@ package cmd
 import (
 	"github.com/openconfig/containerz/client"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
 )
 
 var containerCmd = &cobra.Command{
 	Use:   "container",
 	Short: "General container operations",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if grpcMetadata != nil {
+			ctx := metadata.NewOutgoingContext(cmd.Context(), metadata.New(grpcMetadata))
+			cmd.SetContext(ctx)
+		}
 		var err error
 		containerzClient, err = client.NewClient(cmd.Context(), addr)
 		return err

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -26,6 +26,9 @@ var (
 	containerzClient *client.Client
 	cli              cpb.ContainerzClient
 	image, tag       string
+
+	// NewClient is the function to use to create a new containerz client.
+	NewClient = client.NewClient
 )
 
 var imageCmd = &cobra.Command{
@@ -37,7 +40,7 @@ var imageCmd = &cobra.Command{
 			cmd.SetContext(ctx)
 		}
 		var err error
-		containerzClient, err = client.NewClient(cmd.Context(), addr)
+		containerzClient, err = NewClient(cmd.Context(), addr)
 		return err
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"github.com/openconfig/containerz/client"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
 
 	cpb "github.com/openconfig/gnoi/containerz"
 )
@@ -31,6 +32,10 @@ var imageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "General image operations",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if grpcMetadata != nil {
+			ctx := metadata.NewOutgoingContext(cmd.Context(), metadata.New(grpcMetadata))
+			cmd.SetContext(ctx)
+		}
 		var err error
 		containerzClient, err = client.NewClient(cmd.Context(), addr)
 		return err

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -17,12 +17,17 @@ package cmd
 import (
 	"github.com/openconfig/containerz/client"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
 )
 
 var pluginCmd = &cobra.Command{
 	Use:   "plugin",
 	Short: "General plugin operations",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if grpcMetadata != nil {
+			ctx := metadata.NewOutgoingContext(cmd.Context(), metadata.New(grpcMetadata))
+			cmd.SetContext(ctx)
+		}
 		var err error
 		containerzClient, err = client.NewClient(cmd.Context(), addr)
 		return err

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"github.com/openconfig/containerz/client"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/metadata"
 )
@@ -29,7 +28,7 @@ var pluginCmd = &cobra.Command{
 			cmd.SetContext(ctx)
 		}
 		var err error
-		containerzClient, err = client.NewClient(cmd.Context(), addr)
+		containerzClient, err = NewClient(cmd.Context(), addr)
 		return err
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,8 @@ import (
 )
 
 var (
-	addr string
+	addr         string
+	grpcMetadata map[string]string
 )
 
 // RootCmd is the cmd entrypoint for all containerz commands.
@@ -39,4 +40,5 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.PersistentFlags().StringVar(&addr, "addr", ":19999", "Containerz listen port.")
+	RootCmd.PersistentFlags().StringToStringVar(&grpcMetadata, "grpc_metadata", nil, "gRPC metadata to attach to all outgoing requests.")
 }

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"github.com/openconfig/containerz/client"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/metadata"
 )
@@ -29,7 +28,7 @@ var volumesCmd = &cobra.Command{
 			cmd.SetContext(ctx)
 		}
 		var err error
-		containerzClient, err = client.NewClient(cmd.Context(), addr)
+		containerzClient, err = NewClient(cmd.Context(), addr)
 		return err
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -17,12 +17,17 @@ package cmd
 import (
 	"github.com/openconfig/containerz/client"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
 )
 
 var volumesCmd = &cobra.Command{
 	Use:   "volume",
 	Short: "General volume operations",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if grpcMetadata != nil {
+			ctx := metadata.NewOutgoingContext(cmd.Context(), metadata.New(grpcMetadata))
+			cmd.SetContext(ctx)
+		}
 		var err error
 		containerzClient, err = client.NewClient(cmd.Context(), addr)
 		return err


### PR DESCRIPTION
1. Adds a flag to be able to set grpc metadata in outgoing gRPC requests
2. Allows overriding the function to create a new containerz client by creating an exported global variable NewClient which is used to create the client for the containerz service.