### PR TITLE
server: gracefully handle not receiving content

### DIFF
--- a/server/deploy.go
+++ b/server/deploy.go
@@ -137,6 +137,11 @@ func (s *Server) handleImageTransfer(ctx context.Context, srv cpb.Containerz_Dep
 			}
 
 		case *cpb.DeployRequest_ImageTransferEnd:
+			if chunkWriter.Size() == 0 {
+				// the client has not actually sent us anything.
+				return status.Errorf(codes.Aborted,
+					"no content was transferred over this stream")
+			}
 			if transfer.IsPlugin {
 				if err := moveFile(chunkWriter, filepath.Join(pluginLocation, fmt.Sprintf("%s.tar", transfer.GetName()))); err != nil {
 					return status.Errorf(codes.Internal, "unable to move plugin: %v", err)

--- a/server/deploy_test.go
+++ b/server/deploy_test.go
@@ -293,6 +293,20 @@ func TestDeploy(t *testing.T) {
 			}),
 		},
 		{
+			name:   "no-data-sent",
+			inOpts: []Option{WithAddr("localhost:0"), WithChunkSize(8)},
+			inReqs: buildRequests(t, &cpb.ImageTransfer{
+				Name:      "some-image",
+				Tag:       "some-tag",
+				ImageSize: 16,
+			}, &cpb.ImageTransferEnd{}),
+			wantResponses: buildResponses(t, &cpb.ImageTransferReady{
+				ChunkSize: 8,
+			}),
+			wantErr: status.Errorf(codes.Aborted,
+				"no content was transferred over this stream"),
+		},
+		{
 			name:   "too-much-data-sent",
 			inOpts: []Option{WithAddr("localhost:0"), WithChunkSize(8)},
 			inReqs: buildRequests(t, &cpb.ImageTransfer{


### PR DESCRIPTION
If the client initiates a transfer and attempts to send a TransferEnd before any content has been pushed,
we should return an error.