### PR TITLE
containers/docker: add hook to StartPlugin

### DIFF
--- a/containers/docker/context.go
+++ b/containers/docker/context.go
@@ -1,0 +1,26 @@
+package docker
+
+import (
+	"context"
+	"io"
+)
+
+type startPluginHookKey struct{}
+type startPluginHookFunc func(ctx context.Context,
+	pluginReader io.ReadCloser) (io.ReadCloser, error)
+
+// NewContextWithStartPluginHook attaches a hook that runs during StartPlugin RPC.
+// this hook handles the incoming tar file (with the embedded config.json)
+// before the StartPlugin RPC uses that tar file to create+start a plugin.
+func NewContextWithStartPluginHook(ctx context.Context,
+	startPluginHook startPluginHookFunc) context.Context {
+	return context.WithValue(ctx, startPluginHookKey{}, startPluginHook)
+}
+
+func startPluginHookFromContext(ctx context.Context) startPluginHookFunc {
+	v, ok := ctx.Value(startPluginHookKey{}).(startPluginHookFunc)
+	if !ok {
+		return nil
+	}
+	return v
+}

--- a/containers/docker/plugin_start.go
+++ b/containers/docker/plugin_start.go
@@ -66,6 +66,12 @@ func (m *Manager) PluginStart(ctx context.Context, name, instance, config string
 		return fmt.Errorf("failed to create plugin tar: %w", err)
 	}
 
+	if hook := startPluginHookFromContext(ctx); hook != nil {
+		if createCtx, err = hook(ctx, createCtx); err != nil {
+			return fmt.Errorf("failed to run startup plugin hook with error %s", err)
+		}
+	}
+
 	if err := m.client.PluginCreate(ctx, createCtx, types.PluginCreateOptions{
 		RepoName: instance,
 	}); err != nil {

--- a/containers/docker/plugin_start_test.go
+++ b/containers/docker/plugin_start_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 type fakePluginStartingDocker struct {
 	fakeDocker
 }
-
 
 func (f *fakePluginStartingDocker) PluginCreate(ctx context.Context, createCtx io.Reader, options types.PluginCreateOptions) error {
 	return nil
@@ -29,6 +29,7 @@ func TestPluginStart(t *testing.T) {
 		inInstance string
 		inConfig   string
 		wantErr    bool
+		withHook   startPluginHookFunc
 	}{
 		{
 			name:       "valid-plugin",
@@ -43,18 +44,50 @@ func TestPluginStart(t *testing.T) {
 			inConfig:   "test-config",
 			wantErr:    true,
 		},
+		{
+			name:       "valid-plugin-working-hook",
+			inName:     "data",
+			inInstance: "test-instance",
+			inConfig:   "test-config",
+			withHook: func(ctx context.Context,
+				pluginReader io.ReadCloser) (io.ReadCloser, error) {
+				return pluginReader, nil
+			},
+		},
+		{
+			name:       "valid-plugin-failing-hook",
+			inName:     "data",
+			inInstance: "test-instance",
+			inConfig:   "test-config",
+			withHook: func(ctx context.Context,
+				pluginReader io.ReadCloser) (io.ReadCloser, error) {
+				return nil, fmt.Errorf("failed hook")
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			stagingLocation = t.TempDir()
 			ctx := context.Background()
+			var ranHook bool
+			if tc.withHook != nil {
+				ctx = NewContextWithStartPluginHook(ctx, func(ctx context.Context,
+					pluginReader io.ReadCloser) (io.ReadCloser, error) {
+					ranHook = true
+					return tc.withHook(ctx, pluginReader)
+				})
+			}
+
 			mgr := New(&fakePluginStartingDocker{})
-			if err := mgr.PluginStart(ctx, tc.inName, tc.inInstance, tc.inConfig); err != nil {
-				if tc.wantErr {
-					return
-				}
-				t.Errorf("PluginStart(%q, %q, %q) returned error: %v", tc.inName, tc.inInstance, tc.inConfig, err)
+			if err := mgr.PluginStart(ctx, tc.inName, tc.inInstance,
+				tc.inConfig); (err != nil) != tc.wantErr {
+				t.Errorf("PluginStart(%q, %q, %q) returned error: %v, want error=%t",
+					tc.inName, tc.inInstance, tc.inConfig, err, tc.wantErr)
+			}
+			if (tc.withHook != nil) != ranHook {
+				t.Errorf("failed to run start plugin hook")
 			}
 		})
 	}


### PR DESCRIPTION
add a hook that can be set for the StartPlugin
which will allow for custom handling to be done on the plugin tar before it is sent to docker to create/start