### PR TITLE
all: support starting existing exited containers

### DIFF
--- a/client/start_container.go
+++ b/client/start_container.go
@@ -90,6 +90,7 @@ func startContainerRequestWithOptions(ctx context.Context, image string, tag str
 	if err != nil {
 		return nil, err
 	}
+	limits := limits(optionz.cpus, optionz.softMem, optionz.hardMem)
 
 	return &cpb.StartContainerRequest{
 		ImageName:    image,
@@ -105,12 +106,19 @@ func startContainerRequestWithOptions(ctx context.Context, image string, tag str
 		RunAs:        runAs,
 		Restart:      restartPolicy,
 		Labels:       optionz.labels,
-		Limits: &cpb.StartContainerRequest_Limits{
-			MaxCpu:       optionz.cpus,
-			SoftMemBytes: optionz.softMem,
-			HardMemBytes: optionz.hardMem,
-		},
+		Limits:       limits,
 	}, nil
+}
+
+func limits(cpus float64, softMem, hardMem int64) *cpb.StartContainerRequest_Limits {
+	if cpus == 0 && softMem == 0 && hardMem == 0 {
+		return nil
+	}
+	return &cpb.StartContainerRequest_Limits{
+		MaxCpu:       cpus,
+		SoftMemBytes: softMem,
+		HardMemBytes: hardMem,
+	}
 }
 
 func ports(ports []string) ([]*cpb.StartContainerRequest_Port, error) {
@@ -231,6 +239,9 @@ func restart(policy string) (*cpb.StartContainerRequest_Restart, error) {
 }
 
 func capabilities(capAdd, capRemove []string) (*cpb.StartContainerRequest_Capabilities, error) {
+	if len(capAdd) == 0 && len(capRemove) == 0 {
+		return nil, nil
+	}
 	return &cpb.StartContainerRequest_Capabilities{
 		Add:    capAdd,
 		Remove: capRemove,

--- a/client/start_container_test.go
+++ b/client/start_container_test.go
@@ -434,6 +434,21 @@ func TestStart(t *testing.T) {
 			},
 			wantErr: status.Error(codes.FailedPrecondition, "restart policy `my-policy` is none of always, on-failure, unless-stopped, none"),
 		},
+		{
+			name:       "restart-instance",
+			inInstance: "some-instance",
+			inMsg: &cpb.StartContainerResponse{
+				Response: &cpb.StartContainerResponse_StartOk{
+					StartOk: &cpb.StartOK{
+						InstanceName: "some-instance",
+					},
+				},
+			},
+			wantID: "some-instance",
+			wantMsg: &cpb.StartContainerRequest{
+				InstanceName: "some-instance",
+			},
+		},
 	}
 
 	ctx := context.Background()

--- a/cmd/container_start.go
+++ b/cmd/container_start.go
@@ -40,10 +40,10 @@ var (
 
 var cntStartCmd = &cobra.Command{
 	Use:   "start",
-	Short: "start a container wirth the specified image and tag",
+	Short: "start a container with the specified image and tag, or restart an exited container",
 	RunE: func(command *cobra.Command, args []string) error {
-		if image == "" {
-			return fmt.Errorf("--image must be specified")
+		if instance == "" {
+			return fmt.Errorf("--instance must be specified")
 		}
 
 		opts := []client.StartOption{}
@@ -103,7 +103,7 @@ func init() {
 	containerCmd.AddCommand(cntStartCmd)
 
 	cntStartCmd.PersistentFlags().StringVar(&cntCommand, "command", "/bin/bash", "command to run.")
-	cntStartCmd.PersistentFlags().StringVar(&instance, "instance", "", "Name to give to the container.")
+	cntStartCmd.PersistentFlags().StringVar(&instance, "instance", "", "Name to give to the container (or name of exited container to restart).")
 	cntStartCmd.PersistentFlags().StringVar(&network, "network", "", "Network to attach container to.")
 	cntStartCmd.PersistentFlags().StringVar(&runAs, "runas", "", "User to use (format: <user>[:<group>]")
 	cntStartCmd.PersistentFlags().StringVar(&restartPolicy, "restart_policy", "", "Restart policy to use. "+

--- a/containers/docker/container_start.go
+++ b/containers/docker/container_start.go
@@ -19,6 +19,24 @@ import (
 	cpb "github.com/openconfig/gnoi/containerz"
 )
 
+func (m *Manager) ContainerRestart(ctx context.Context, instance string, _ ...options.Option) error {
+	cnts, err := m.client.ContainerList(ctx, container.ListOptions{All: true})
+	if err != nil {
+		return err
+	}
+	j, err := m.jsonState(ctx, instance, cnts)
+	if err != nil {
+		return err
+	}
+	if j.State.Status != container.StateExited {
+		// when we're calling ContainerRestart we expect that the container is currently exited,
+		// but its possible that the container has now restarted, and so we should just error here
+		return status.Errorf(codes.Aborted, "expected container state to be %q, got %q",
+			container.StateExited, j.State.Status)
+	}
+	return m.restartContainer(ctx, j, true)
+}
+
 // ContainerStart starts a container provided the image exists and that the ports requested are not
 // currently in use.
 func (m *Manager) ContainerStart(ctx context.Context, imageName, tag, cmd string, opts ...options.Option) (string, error) {

--- a/containers/docker/container_update.go
+++ b/containers/docker/container_update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/openconfig/containerz/containers"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
@@ -85,7 +86,7 @@ func (m *Manager) performContainerUpdate(ctx context.Context, instance, image, t
 					" should return status error code, got %s: %s",
 				errPfx, recreateErr)
 		}
-		return "", status.Errorf(s.Code(), fmt.Sprintf("%s; %s", errPfx, recreateErr))
+		return "", status.Errorf(s.Code(), "%s; %s", errPfx, recreateErr)
 	}
 
 	return instance, status.Errorf(codes.Internal, "%s; yet, restoration of previous state succeeded", errPfx)

--- a/containers/docker/container_update.go
+++ b/containers/docker/container_update.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types"
+	"github.com/openconfig/containerz/containers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
-	"github.com/openconfig/containerz/containers"
 )
 
 type instanceConfig struct {
@@ -73,18 +73,49 @@ func (m *Manager) performContainerUpdate(ctx context.Context, instance, image, t
 	}
 
 	// There was some error, let's try to restore previous state.
-	errPfx := fmt.Sprintf("failed to update instance %s due to: %v", instance, err)
+	errPfx := fmt.Sprintf("failed to update instance %s due to:"+
+		" restoration of previous state %v", instance, err)
 
-	resp, err := m.client.ContainerCreate(ctx, oldCntJSON.Config, oldCntJSON.HostConfig, &network.NetworkingConfig{}, nil, instance)
-	if err != nil {
-		return "", status.Errorf(codes.Internal, "%s; restoration of previous state failed when creating container: %v", errPfx, err)
-	}
-
-	if err := m.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
-		return "", status.Errorf(codes.Internal, "%s; restoration of previous state failed when starting container: %v", errPfx, err)
+	if recreateErr := m.restartContainer(ctx, oldCntJSON,
+		false); recreateErr != nil {
+		s, ok := status.FromError(recreateErr)
+		if !ok {
+			return "", fmt.Errorf(
+				"programming error: restartContainer"+
+					" should return status error code, got %s: %s",
+				errPfx, recreateErr)
+		}
+		return "", status.Errorf(s.Code(), fmt.Sprintf("%s; %s", errPfx, recreateErr))
 	}
 
 	return instance, status.Errorf(codes.Internal, "%s; yet, restoration of previous state succeeded", errPfx)
+}
+
+// restartContainer recreates a container given a particular config.
+// it is expected that the container in question has been stopped by the point this is called.
+func (m *Manager) restartContainer(ctx context.Context, oldCntJSON types.ContainerJSON,
+	needsRemoval bool) error {
+	instanceName := strings.Replace(oldCntJSON.Name, "/", "", 1)
+	if needsRemoval {
+		if err := m.client.ContainerRemove(ctx, instanceName,
+			container.RemoveOptions{}); err != nil {
+			return status.Errorf(codes.Internal,
+				"failed when removing container: %v", err)
+		}
+	}
+	resp, err := m.client.ContainerCreate(ctx,
+		oldCntJSON.Config, oldCntJSON.HostConfig, &network.NetworkingConfig{},
+		nil, instanceName)
+	if err != nil {
+		return status.Errorf(codes.Internal,
+			"failed when creating container: %v", err)
+	}
+
+	if err := m.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		return status.Errorf(codes.Internal,
+			"failed when starting container: %v", err)
+	}
+	return nil
 }
 
 func (m *Manager) performContainerUpdatePrechecks(ctx context.Context, instance, imageName, tag, cmd string, async bool, opts ...options.Option) ([]types.Container, error) {

--- a/containers/docker/container_update.go
+++ b/containers/docker/container_update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
-	"github.com/openconfig/containerz/containers"
+	options "github.com/openconfig/containerz/containers"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -74,8 +74,7 @@ func (m *Manager) performContainerUpdate(ctx context.Context, instance, image, t
 	}
 
 	// There was some error, let's try to restore previous state.
-	errPfx := fmt.Sprintf("failed to update instance %s due to:"+
-		" restoration of previous state %v", instance, err)
+	errPfx := fmt.Sprintf("failed to update instance %s due to: %v", instance, err)
 
 	if recreateErr := m.restartContainer(ctx, oldCntJSON,
 		false); recreateErr != nil {
@@ -86,7 +85,7 @@ func (m *Manager) performContainerUpdate(ctx context.Context, instance, image, t
 					" should return status error code, got %s: %s",
 				errPfx, recreateErr)
 		}
-		return "", status.Errorf(s.Code(), "%s; %s", errPfx, recreateErr)
+		return "", status.Errorf(s.Code(), "%s; restoration of previous state %s", errPfx, recreateErr)
 	}
 
 	return instance, status.Errorf(codes.Internal, "%s; yet, restoration of previous state succeeded", errPfx)

--- a/containers/options.go
+++ b/containers/options.go
@@ -111,6 +111,9 @@ type options struct {
 	// All indicates that we should return all containers regardless of their state.
 	All bool
 
+	// ListAll indicates we should list all containers when searching for stopped containers
+	ListAll bool
+
 	// Limit restricts the total number of responses.
 	Limit int
 
@@ -158,6 +161,14 @@ type options struct {
 
 	// Devices is the set of devices to attach to the container.
 	Devices []*cpb.Device
+}
+
+// WithListAll causes list operations to return all containers
+// Supported by: StartContainer
+func WithListAll() Option {
+	return func(p *options) {
+		p.ListAll = true
+	}
 }
 
 // WithTarget sets the target image name and tag option for this pull operation.

--- a/server/deploy_test.go
+++ b/server/deploy_test.go
@@ -102,6 +102,12 @@ func (f *fakeContainerManager) ContainerRemove(_ context.Context, instance strin
 	return fmt.Errorf("not found")
 }
 
+func (f *fakeContainerManager) ContainerRestart(_ context.Context,
+	instance string, opts ...options.Option) error {
+	f.Instance = instance
+	return nil
+}
+
 func (f *fakeContainerManager) ContainerStart(_ context.Context, image string, tag string, cmd string, opts ...options.Option) (string, error) {
 	optionz := options.ApplyOptions(opts...)
 	f.Image = image
@@ -188,7 +194,7 @@ func (f *fakeContainerManager) ImageList(ctx context.Context, all bool, limit in
 	return nil
 }
 
-func (f fakeContainerManager) ImageRemove(context.Context, string, string, ...options.Option) error {
+func (f *fakeContainerManager) ImageRemove(context.Context, string, string, ...options.Option) error {
 	return f.removeError
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -81,6 +81,14 @@ type containerManager interface {
 	// started container.
 	ContainerStart(context.Context, string, string, string, ...options.Option) (string, error)
 
+	// ContainerRestart restarts a stopped container
+	//
+	// It takes:
+	// - instance (string): the instance name of the existing exited container to restart
+	//
+	// It returns an error indicating if the start operation succeeded
+	ContainerRestart(context.Context, string, ...options.Option) error
+
 	// ContainerStop stops a container. If the Force option is passed it will forcefully stop
 	// (kill) the container. A stop timeout can be provided via the context otherwise the
 	// system default will be used.
@@ -91,7 +99,7 @@ type containerManager interface {
 	// It returns an error indicating whether the result was successful
 	ContainerStop(context.Context, string, ...options.Option) error
 
-	// ContainerUpdates updates an existing container.
+	// ContainerUpdate updates an existing container.
 	//
 	// It takes:
 	// - instance (string): the instance name of the running container.

--- a/server/start_container.go
+++ b/server/start_container.go
@@ -16,12 +16,14 @@ package server
 
 import (
 	"context"
+	"strings"
 
 	options "github.com/openconfig/containerz/containers"
 	cpb "github.com/openconfig/gnoi/containerz"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -34,22 +36,106 @@ const (
 // should provide one. If the instance name already exists, the target should
 // return an error.
 func (s *Server) StartContainer(ctx context.Context, request *cpb.StartContainerRequest) (*cpb.StartContainerResponse, error) {
-	opts, err := optionsFromStartContainerRequest(request)
+	instanceName := request.GetInstanceName()
+	existingState, err := existingContainerState(ctx, s, instanceName)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.mgr.ContainerStart(ctx, request.GetImageName(), request.GetTag(), request.GetCmd(), opts...)
-	if err != nil {
-		return nil, err
+	switch existingState {
+	case cpb.ListContainerResponse_STOPPED:
+		if !isRestartContainerRequest(request) {
+			return nil, status.Errorf(codes.InvalidArgument, "instance %q is stopped. please provide"+
+				" only the instance name to restart it. got request=%s", instanceName, request)
+		}
+		if err = s.mgr.ContainerRestart(ctx, instanceName); err != nil {
+			return nil, err
+		}
+	case cpb.ListContainerResponse_NOT_FOUND,
+		cpb.ListContainerResponse_UNSPECIFIED:
+		opts, err := optionsFromStartContainerRequest(request)
+		if err != nil {
+			return nil, err
+		}
+		// if instance name was not specified in the request, then ContainerStart will
+		// override it here with a generated container name.
+		instanceName, err = s.mgr.ContainerStart(ctx, request.GetImageName(), request.GetTag(), request.GetCmd(), opts...)
+		if err != nil {
+			return nil, err
+		}
+	case cpb.ListContainerResponse_RUNNING,
+		cpb.ListContainerResponse_PRESENT:
+		return nil, status.Errorf(codes.AlreadyExists,
+			"instance name %s already in use", instanceName)
+	default:
+		return nil, status.Errorf(codes.Unknown,
+			"unexpected current state of container %s", existingState)
 	}
 
 	return &cpb.StartContainerResponse{
 		Response: &cpb.StartContainerResponse_StartOk{
 			StartOk: &cpb.StartOK{
-				InstanceName: resp,
+				InstanceName: instanceName,
 			},
 		},
 	}, nil
+}
+
+type localListContainer struct {
+	cnts []*cpb.ListContainerResponse
+}
+
+var _ options.ListContainerStreamer = &localListContainer{}
+
+func (c *localListContainer) Send(msg *cpb.ListContainerResponse) error {
+	c.cnts = append(c.cnts, msg)
+	return nil
+}
+
+func existingContainerState(ctx context.Context, s *Server, instance string) (cpb.ListContainerResponse_Status, error) {
+	if instance == "" {
+		// no instance name provided, so we cannot be checking for a stopped container here.
+		return cpb.ListContainerResponse_UNSPECIFIED, nil
+	}
+	const (
+		all   = true
+		limit = 1
+	)
+	capture := &localListContainer{}
+	if err := s.mgr.ContainerList(ctx, all, limit, capture, options.WithFilter(
+		map[options.FilterKey][]string{
+			"name": {instance},
+		})); err != nil {
+		return cpb.ListContainerResponse_UNSPECIFIED, status.Errorf(codes.Unknown,
+			"failed to check if container %q is running, with error %s", instance, err)
+	}
+	if len(capture.cnts) == 0 {
+		// no containers were running with this instance name
+		return cpb.ListContainerResponse_NOT_FOUND, nil
+	}
+	var foundName bool
+	for i := 0; i < len(capture.cnts) && !foundName; i++ {
+		foundName = instance == strings.Replace(capture.cnts[i].Name, "/", "", 1)
+	}
+	if !foundName {
+		return cpb.ListContainerResponse_NOT_FOUND, nil
+	}
+	return capture.cnts[0].GetStatus(), nil
+}
+
+// isRestartContainerRequest checks if the request was empty apart from the
+// instance name being set.
+func isRestartContainerRequest(request *cpb.StartContainerRequest) bool {
+	cloned := proto.Clone(request)
+	reqCopy := cloned.(*cpb.StartContainerRequest)
+	if reqCopy.InstanceName == "" {
+		// restarting existing containers requires instance name to be set
+		// so we should never hit this.
+		return false
+	}
+	reqCopy.InstanceName = ""
+	empty := new(cpb.StartContainerRequest)
+	empty.Reset()
+	return proto.Equal(reqCopy, empty)
 }
 
 func optionsFromStartContainerRequest(request *cpb.StartContainerRequest) ([]options.Option, error) {

--- a/server/start_container.go
+++ b/server/start_container.go
@@ -44,8 +44,9 @@ func (s *Server) StartContainer(ctx context.Context, request *cpb.StartContainer
 	switch existingState {
 	case cpb.ListContainerResponse_STOPPED:
 		if !isRestartContainerRequest(request) {
-			return nil, status.Errorf(codes.InvalidArgument, "instance %q is stopped. please provide"+
-				" only the instance name to restart it. got request=%s", instanceName, request)
+			return nil, status.Errorf(codes.InvalidArgument,
+				"instance %q is stopped. please provide only the instance name to restart it",
+				instanceName)
 		}
 		if err = s.mgr.ContainerRestart(ctx, instanceName); err != nil {
 			return nil, err

--- a/server/start_container_test.go
+++ b/server/start_container_test.go
@@ -599,14 +599,13 @@ func TestContainerStart(t *testing.T) {
 			},
 		},
 		{
-			name: "restart-request-for-stopped-container",
+			name: "restart-request-for-stopped-container-image",
 			inReq: &cpb.StartContainerRequest{
 				InstanceName: "restart-me",
 				ImageName:    "xy",
 			},
 			wantErr: status.Errorf(codes.InvalidArgument,
-				"instance %q is stopped. please provide only the instance name to restart it."+
-					` got request=image_name:"xy" instance_name:"restart-me"`,
+				"instance %q is stopped. please provide only the instance name to restart it",
 				"restart-me"),
 			fcm: &fakeContainerManager{
 				listCntMsgs: []*cpb.ListContainerResponse{{

--- a/server/start_container_test.go
+++ b/server/start_container_test.go
@@ -37,6 +37,7 @@ func TestContainerStart(t *testing.T) {
 		wantResp  *cpb.StartContainerResponse
 		wantState *fakeContainerManager
 		wantErr   error
+		fcm       *fakeContainerManager
 	}{
 		{
 			name: "simple",
@@ -117,6 +118,8 @@ func TestContainerStart(t *testing.T) {
 				},
 			},
 			wantState: &fakeContainerManager{
+				All:   true,
+				Limit: 1,
 				Labels: map[string]string{
 					locationLabel: cpb.StartContainerRequest_L_PRIMARY.String()},
 				Image:    "some-image",
@@ -573,12 +576,189 @@ func TestContainerStart(t *testing.T) {
 				Cmd:   "some-cmd",
 			},
 		},
+		{
+			// this restart request will fail, and become just a normal StartContainer request,
+			// but with no image,cmds,config etc.
+			// in reality this will lead to an error on the non-mocked mgr
+			name: "restart-request-non-existing-container",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me",
+			},
+			wantResp: &cpb.StartContainerResponse{
+				Response: &cpb.StartContainerResponse_StartOk{
+					StartOk: &cpb.StartOK{},
+				},
+			},
+			wantState: &fakeContainerManager{
+				All:      true,
+				Limit:    1,
+				Instance: "restart-me",
+				Labels: map[string]string{
+					locationLabel: cpb.StartContainerRequest_L_PRIMARY.String(),
+				},
+			},
+		},
+		{
+			name: "restart-request-for-stopped-container",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me",
+				ImageName:    "xy",
+			},
+			wantErr: status.Errorf(codes.InvalidArgument,
+				"instance %q is stopped. please provide only the instance name to restart it."+
+					` got request=image_name:"xy" instance_name:"restart-me"`,
+				"restart-me"),
+			fcm: &fakeContainerManager{
+				listCntMsgs: []*cpb.ListContainerResponse{{
+					Name:   "/restart-me",
+					Status: cpb.ListContainerResponse_STOPPED,
+				}},
+			},
+			wantState: &fakeContainerManager{
+				All:   true,
+				Limit: 1,
+			},
+		},
+		{
+			name: "restart-request-for-stopped-container",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me",
+			},
+			wantResp: &cpb.StartContainerResponse{
+				Response: &cpb.StartContainerResponse_StartOk{
+					StartOk: &cpb.StartOK{
+						InstanceName: "restart-me",
+					},
+				},
+			},
+			fcm: &fakeContainerManager{
+				listCntMsgs: []*cpb.ListContainerResponse{{
+					Name:   "/restart-me",
+					Status: cpb.ListContainerResponse_STOPPED,
+				}},
+			},
+			wantState: &fakeContainerManager{
+				All:      true,
+				Limit:    1,
+				Instance: "restart-me",
+			},
+		},
+		{
+			name: "restart-request-for-specific-stopped-container",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me-specific",
+			},
+			wantResp: &cpb.StartContainerResponse{
+				Response: &cpb.StartContainerResponse_StartOk{
+					StartOk: &cpb.StartOK{
+						InstanceName: "restart-me-specific",
+					},
+				},
+			},
+			fcm: &fakeContainerManager{
+				listCntMsgs: []*cpb.ListContainerResponse{{
+					Name:   "/restart-me-specific-something-else",
+					Status: cpb.ListContainerResponse_STOPPED,
+				}, {
+					Name:   "/restart-me-specific",
+					Status: cpb.ListContainerResponse_STOPPED,
+				}},
+			},
+			wantState: &fakeContainerManager{
+				All:      true,
+				Limit:    1,
+				Instance: "restart-me-specific",
+			},
+		},
+		{
+			name: "restart-request-for-running-container",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me-running",
+			},
+			wantErr: status.Errorf(codes.AlreadyExists,
+				"instance name restart-me-running already in use"),
+			fcm: &fakeContainerManager{
+				listCntMsgs: []*cpb.ListContainerResponse{{
+					Name:   "/restart-me-running",
+					Status: cpb.ListContainerResponse_RUNNING,
+				}},
+			},
+			wantState: &fakeContainerManager{
+				All:   true,
+				Limit: 1,
+			},
+		},
+		{
+			name: "restart-request-for-present-container",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me-present",
+			},
+			wantErr: status.Errorf(codes.AlreadyExists,
+				"instance name restart-me-present already in use"),
+			fcm: &fakeContainerManager{
+				listCntMsgs: []*cpb.ListContainerResponse{{
+					Name:   "/restart-me-present",
+					Status: cpb.ListContainerResponse_PRESENT,
+				}},
+			},
+			wantState: &fakeContainerManager{
+				All:   true,
+				Limit: 1,
+			},
+		},
+		{
+			name: "restart-request-for-not-found-no-containers",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me-not-found-in-list",
+			},
+			fcm: &fakeContainerManager{
+				listCntMsgs: []*cpb.ListContainerResponse{},
+			},
+			wantResp: &cpb.StartContainerResponse{
+				Response: &cpb.StartContainerResponse_StartOk{
+					StartOk: &cpb.StartOK{},
+				},
+			},
+			wantState: &fakeContainerManager{
+				All:      true,
+				Limit:    1,
+				Instance: "restart-me-not-found-in-list",
+				Labels: map[string]string{
+					locationLabel: cpb.StartContainerRequest_L_PRIMARY.String()},
+			},
+		},
+		{
+			name: "restart-request-for-not-found-non-empty",
+			inReq: &cpb.StartContainerRequest{
+				InstanceName: "restart-me-not-found-in-list",
+			},
+			fcm: &fakeContainerManager{
+				listCntMsgs: []*cpb.ListContainerResponse{{
+					Name: "/other-things",
+				}},
+			},
+			wantResp: &cpb.StartContainerResponse{
+				Response: &cpb.StartContainerResponse_StartOk{
+					StartOk: &cpb.StartOK{},
+				},
+			},
+			wantState: &fakeContainerManager{
+				All:      true,
+				Limit:    1,
+				Instance: "restart-me-not-found-in-list",
+				Labels: map[string]string{
+					locationLabel: cpb.StartContainerRequest_L_PRIMARY.String()},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			fake := &fakeContainerManager{}
+			if tc.fcm != nil {
+				fake = tc.fcm
+			}
 			tc.inOpts = append(tc.inOpts, WithAddr("localhost:0"))
 			cli, s := startServerAndReturnClient(ctx, t, fake, tc.inOpts)
 			defer s.Halt(ctx)


### PR DESCRIPTION
The proto spec mentions:
"""
When the instance name already exists,
the target should return an error if the container is running or if it is stopped but the request
has more fields than just the instance name.
If the container is stopped and the request
contains only the instance name then Start
should start the container.
"""
https://github.com/openconfig/gnoi/blob/b2cfe7eb561014631a4f4878fe78bfe7b6a0ab83/containerz/containerz.proto#L93-L97

This commit adds that functionality to the StartContainer RPC. 
We check if the container is stopped (or even present/running) at the start of the RPC, and then based on that check we decide to either start/restart it.
the same error codes/messages are retained in the event that we are targeting an instance that already exists and is running, i.e. (code=ALREADY_EXISTS, message= "instance name %s already in use"

It reuses some of the functions shared with UpdateContainer to handle recreating containers, so part of this code is a refactor.